### PR TITLE
docs: replace placeholder READMEs

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,10 @@
-TODO: Create README
+# GKORM Repository
+
+This repository hosts the GKORM full-stack application.
+
+## Contents
+
+- `gkorm/` – project source including API, database, and frontend services.
+- `LICENSE.md` – license information for the project.
+
+See the README files in each directory for more details.

--- a/gkorm/README.md
+++ b/gkorm/README.md
@@ -1,1 +1,10 @@
-TODO: Create README
+# GKORM Project
+
+This directory contains the core services that make up the GKORM application. Each service can be run individually or together with Docker Compose.
+
+## Structure
+
+- `api/` – FastAPI backend that exposes mission and user endpoints.
+- `database/` – database container and schema notes.
+- `frontend/` – Next.js user interface.
+- `docker-compose.yml` – orchestrates the services for local development.

--- a/gkorm/api/README.md
+++ b/gkorm/api/README.md
@@ -1,1 +1,8 @@
-TODO: Create README
+# API
+
+The FastAPI backend for GKORM lives in this directory.
+
+- `main.py` – application entrypoint that configures routes and CORS.
+- `app/` – package containing database models, route definitions, and utilities.
+- `requirements.txt` – Python dependencies for the service.
+- `Dockerfile` – container definition for running the API.

--- a/gkorm/database/README.md
+++ b/gkorm/database/README.md
@@ -1,1 +1,6 @@
-TODO: Create README
+# Database
+
+This directory provides the database resources for the GKORM application.
+
+- `Dockerfile` – builds the database image used by Docker Compose.
+- `notes.txt` – design notes covering enums, tables, and relationships.

--- a/gkorm/frontend/README.md
+++ b/gkorm/frontend/README.md
@@ -1,1 +1,17 @@
-TODO: Create README
+# Frontend
+
+This directory contains the Next.js user interface for GKORM.
+
+- `app/`, `components/`, and `context/` – source for pages, UI elements, and state management.
+- `api/` – client-side API helpers.
+- `package.json` – Node dependencies and useful scripts such as `dev`, `build`, and `lint`.
+- `Dockerfile` – container specification for the frontend service.
+
+## Development
+
+Install dependencies and start the development server:
+
+```bash
+npm install
+npm run dev
+```


### PR DESCRIPTION
## Summary
- Replace placeholder README content with project descriptions at the repository root and service directories
- Document API, database, and frontend layouts

## Testing
- `python -m py_compile $(find gkorm/api -name '*.py')`
- `cd gkorm/frontend && npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68c5630380e8832991756630e0691b01